### PR TITLE
Exclude ETK from Built Javadocs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,6 +173,9 @@
           <finalName>${project.artifactId}-${project.version}</finalName>
           <show>private</show>
           <includeDependencySources>true</includeDependencySources>
+          <dependencySourceExcludes>
+            <dependencySourceExclude>com.hms_networks.americas.sc.mvnlibs:ewon-etk:*</dependencySourceExclude>
+          </dependencySourceExcludes>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
@oliver-walker-hms @TomKimsey This commit resolves some soft errors that didn't stop the Maven build, but displayed a couple of red error messages in the build output. 

The ETK Javadocs were already not included because they do not exist in Maven, so this PR is explicitly excluding them so Maven doesn't even attempt to resolve/download.