### PR TITLE
Maven External Properties Tweak and IDE File Change

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="Encoding">
     <file url="file://$PROJECT_DIR$/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/src/main/resources" charset="UTF-8" />
   </component>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -314,6 +314,30 @@
         </executions>
       </plugin>
 
+      <!-- Mark flexy.properties as assume unchanged-->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.6.0</version>
+        <executions>
+          <execution>
+            <id>git-assume-unchanged-flexy-properties</id>
+            <phase>initialize</phase>
+            <configuration>
+              <executable>git</executable>
+              <arguments>
+                <argument>update-index</argument>
+                <argument>--assume-unchanged</argument>
+                <argument>${project.basedir}/flexy.properties</argument>
+              </arguments>
+            </configuration>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
       <!-- Read properties from external file -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
@@ -382,12 +406,14 @@
         <activeByDefault>true</activeByDefault>
       </activation>
       <properties>
+        <!--suppress UnresolvedMavenProperty -->
         <project.build.exec.url>http://${ewon.address}/rcgi.bin/jvmCmd?cmd=start&amp;runCmd=%20-heapsize%20${project.heap.size}%20-classpath%20/usr/${project.artifactId}-${project.version}-full.jar%20-emain%20${project.main.class}</project.build.exec.url>
       </properties>
     </profile>
     <profile>
       <id>debug</id>
       <properties>
+        <!--suppress UnresolvedMavenProperty -->
         <project.build.exec.url>http://${ewon.address}/rcgi.bin/jvmCmd?cmd=start&amp;runCmd=%20-heapsize%20${project.heap.size}%20-classpath%20/usr/${project.artifactId}-${project.version}-full.jar%20-emain%20${project.main.class}%20-debugger%20-port%20${project.build.debug.port}</project.build.exec.url>
       </properties>
       <build>
@@ -418,6 +444,7 @@
     <profile>
       <id>debugNoSuspend</id>
       <properties>
+        <!--suppress UnresolvedMavenProperty -->
         <project.build.exec.url>http://${ewon.address}/rcgi.bin/jvmCmd?cmd=start&amp;runCmd=%20-heapsize%20${project.heap.size}%20-classpath%20/usr/${project.artifactId}-${project.version}-full.jar%20-emain%20${project.main.class}%20-debugger%20-port%20${project.build.debug.port}%20-nosuspend</project.build.exec.url>
       </properties>
       <build>


### PR DESCRIPTION
Projects implementing this behavior in Maven will no longer be burdened by Git or the IDE showing custom changes to the flexy.properties file and will no longer see unresolved property errors for external properties during validation.