### PR TITLE
Remove actions support for master

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -1,6 +1,6 @@
 # HMS Networks Solution Center
 # Artifact Build Action for Maven-based Ewon ETK Projects
-# Version: 2.0
+# Version: 2.1
 #
 # This action is configured to automatically run when a push
 # is made or pull request is merged to the `main` or `master`
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - master
 
 jobs:
   build:

--- a/.github/workflows/code-format-test.yml
+++ b/.github/workflows/code-format-test.yml
@@ -1,6 +1,6 @@
 # HMS Networks Solution Center
 # Code Format Test Action for Maven-based Ewon ETK Projects
-# Version: 2.0
+# Version: 2.1
 #
 # This action is configured to automatically run when a push
 # is made or pull request is merged to the `main` or `master`
@@ -12,11 +12,9 @@ on:
   pull_request:
     branches:
       - main
-      - master
   push:
     branches:
       - main
-      - master
 
 jobs:
   formatting:

--- a/.github/workflows/commit-format-check.yml
+++ b/.github/workflows/commit-format-check.yml
@@ -1,6 +1,6 @@
 # HMS Networks Solution Center
 # Commit Format Action for Maven-based Ewon ETK Projects
-# Version: 2.0
+# Version: 2.1
 #
 # This action is configured to automatically run when a pull
 # request is made to the `main` or `master` branch.
@@ -11,7 +11,6 @@ on:
   pull_request:
     branches:
       - main
-      - master
 
 jobs:
   check-commit-message:

--- a/.github/workflows/compile-test.yml
+++ b/.github/workflows/compile-test.yml
@@ -1,6 +1,6 @@
 # HMS Networks Solution Center
 # Compile Test Action for Maven-based Ewon ETK Projects
-# Version: 2.0
+# Version: 2.1
 #
 # This action is configured to automatically run when a push
 # is made or pull request is merged to the `main` or `master`
@@ -12,11 +12,9 @@ on:
   pull_request:
     branches:
       - main
-      - master
   push:
     branches:
       - main
-      - master
 
 jobs:
   build:

--- a/.github/workflows/junit-test.yml
+++ b/.github/workflows/junit-test.yml
@@ -1,6 +1,6 @@
 # HMS Networks Solution Center
 # JUnit Test Action for Maven-based Ewon ETK Projects
-# Version: 2.0
+# Version: 2.1
 #
 # This action is configured to automatically run when a push
 # is made or pull request is merged to the `main` or `master`
@@ -12,11 +12,9 @@ on:
   pull_request:
     branches:
       - main
-      - master
   push:
     branches:
       - main
-      - master
 
 jobs:
   build:


### PR DESCRIPTION
Remove support for the primary branch of
a repository to be named 'master'.