### PR TITLE
Fix documentation IDs

### DIFF
--- a/web-docs/docs/04-setup/01-USING_TEMPLATE.mdx
+++ b/web-docs/docs/04-setup/01-USING_TEMPLATE.mdx
@@ -1,5 +1,5 @@
 ---
-id: usage-using-template
+id: using-template
 title: Using Template
 sidebar_label: Using Template
 toc_max_heading_level: 2

--- a/web-docs/docs/04-setup/02-CONFIGURATION.mdx
+++ b/web-docs/docs/04-setup/02-CONFIGURATION.mdx
@@ -1,5 +1,5 @@
 ---
-id: usage-configuration
+id: configuration
 title: Configuration
 sidebar_label: Configuration
 ---


### PR DESCRIPTION
Fixed the IDs for the documents in 04-setup so
that they no longer use the `usage-` prefix.
The `usage-` prefix was incorrect for the
parent folder.

My original implementations included a prefix,
but I later removed prefixes as they are redundant in the URL, and provide no additional value. These instances of `usage-` should have been removed
anyways.