### PR TITLE
Define basic IntelliJ markdown styling

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -92,6 +92,11 @@
       <option name="JD_KEEP_EMPTY_RETURN" value="false" />
       <option name="JD_INDENT_ON_CONTINUATION" value="true" />
     </JavaCodeStyleSettings>
+    <Markdown>
+      <option name="MAX_LINES_AROUND_HEADER" value="0" />
+      <option name="MAX_LINES_AROUND_BLOCK_ELEMENTS" value="0" />
+      <option name="MAX_LINES_BETWEEN_PARAGRAPHS" value="0" />
+    </Markdown>
     <Objective-C>
       <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
       <option name="INDENT_C_STRUCT_MEMBERS" value="2" />


### PR DESCRIPTION
Defined the basic styling configuration for
Markdown in the IntelliJ code style config.

This prevents changelogs from being auto-
formatted unexpectedly when no spacing is
used between headers.