### PR TITLE
#47 - Update commit format action to support Dependabot formats 

### DIFF
--- a/.github/workflows/commit-format-check.yml
+++ b/.github/workflows/commit-format-check.yml
@@ -16,6 +16,7 @@ jobs:
   check-commit-message:
     name: Check Commit Message
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Check Title Line Length
         uses: gsactions/commit-message-checker@v2


### PR DESCRIPTION
closes #47.

Updated the commit format check action so that it
is not run for pull requests created by Dependabot.

This prevents an expected failure of the commit
format action that cannot be corrected within
Dependabot without reducing its functionality or
disconnecting it from the Dependabot automatic
system.