### PR TITLE
Add auto-assign.yml GitHub config

### DIFF
--- a/.github/auto-assign.yml
+++ b/.github/auto-assign.yml
@@ -1,0 +1,19 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: author
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - alexjhawk
+  - it-hms
+  - TomKimsey
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 2
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+skipKeywords:
+  - wip


### PR DESCRIPTION
Adds the auto-assign.yml configuration file for the GitHub probot which auto assigns reviewers and the assignee of pull requests.