### PR TITLE
Added configFileName to ScDocusaurusConfig.js

### DIFF
--- a/web-docs/ScDocusaurusConfig.js
+++ b/web-docs/ScDocusaurusConfig.js
@@ -5,6 +5,7 @@ const ScDocusaurusConfig = {
   title: 'Solution Center Java Starter Project',
   description: 'Kick off Java development on the Ewon Flexy with the HMS Networks Solution Center Java Starter Project.',
   meta: 'Homepage for the HMS Networks MU Americas Solution Center Java Starter Project.',
+  configFileName : 'ExampleConfigurationFile.json',
 };
 
 // EXPORT ZONE - DON'T TOUCH BELOW THIS LINE

--- a/web-docs/docs/02-CHANGELOG.mdx
+++ b/web-docs/docs/02-CHANGELOG.mdx
@@ -5,6 +5,11 @@ sidebar_label: Change Log
 toc_max_heading_level: 2
 ---
 
+## Version X.Y.Z
+### Features
+- Added configFileName to ScDocusaurusConfig.js
+  - Documentation now has access to refrence the config file name as a configurable parameter
+
 ## Version 0.0.5
 ### Features
 - Added Checkstyle configuration for code style and formatting enforcement

--- a/web-docs/docs/04-setup/02-CONFIGURATION.mdx
+++ b/web-docs/docs/04-setup/02-CONFIGURATION.mdx
@@ -95,3 +95,8 @@ to display the project's description on the home page.
 The `meta` field modifies the project's meta information. This field is used by the documentation
 to include meta information in the project's HTML pages, which is used by search engines and
 social media websites to display information about the project and/or documentation website.
+
+#### configFileName
+
+The `configFileName` field modifies the project's configuration file name. This field is used by
+the documentation to display the name of the configuration file used by the application.


### PR DESCRIPTION
Making the configuration file name a config parameter in the documentation opens a lot of doors to be able to reuse sections of documentation across projects.

