### PR TITLE
Fix bug in doc-deploy.yml

### DIFF
--- a/.github/workflows/doc-deploy.yml
+++ b/.github/workflows/doc-deploy.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: aactions/setup-node@v4
+        uses: actions/setup-node@v4
         with:
           node-version: 18
           cache: yarn


### PR DESCRIPTION
Fixed a bug in doc-deploy.yml which was
caused by an improper uses statement that
contained a type `aactions/setup-node@v4`.